### PR TITLE
Adds deterministic namespace in generated test file path

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
   ],
   parserOptions: {
     ecmaVersion: 2019,
-    sourceType: 'module',
+    sourceType: 'script',
   },
   overrides: [
     {

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ npm install ember-add-in-repo-tests
 ```
 
 Import the function
+
 ```javascript
 const { addInRepoTestsToHost } = require('ember-add-in-repo-tests');
 ```
@@ -60,19 +61,43 @@ module.exports = {
 We can define the predicate as
 
 ```javascript
-const inRepoAddonPredicate = addon => addon.includeTestsInHost;
+const shouldIncludeTestsInHost = (addon) => addon.includeTestsInHost;
 ```
 
 We can now override the test tree in `ember-cli-build`. Full code below
 
 ```javascript
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
-const inRepoAddonPredicate = (addon) => addon.includeTestsInHost;
+const shouldIncludeTestsInHost = (addon) => addon.includeTestsInHost;
 
-module.exports = function(defaults) {
+module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
     trees: {
-      tests: addInRepoTestsToHost(defaults.project, inRepoAddonPredicate),
+      tests: addInRepoTestsToHost({
+        project: defaults.project,
+        shouldIncludeTestsInHost,
+      }),
+    },
+  });
+
+  return app.toTree();
+};
+```
+
+You can additionally pass in a `projectRoot` to the options to override the root of the project. By default, `projectRoot` is `defaults.project.root`.
+
+```javascript
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+const shouldIncludeTestsInHost = (addon) => addon.includeTestsInHost;
+
+module.exports = function (defaults) {
+  let app = new EmberApp(defaults, {
+    trees: {
+      tests: addInRepoTestsToHost({
+        project: defaults.project,
+        projectRoot: customProjectRoot,
+        shouldIncludeTestsInHost,
+      }),
     },
   });
 

--- a/__tests__/add-tests-to-host-test.js
+++ b/__tests__/add-tests-to-host-test.js
@@ -1,30 +1,30 @@
-'use strict';
+"use strict";
 
-const { createTempDir, createBuilder } = require('broccoli-test-helper');
-const { glob } = require('glob');
+const { createTempDir, createBuilder } = require("broccoli-test-helper");
+const { glob } = require("glob");
 
-const fs = require('fs');
-const Funnel = require('broccoli-funnel');
+const fs = require("fs");
+const Funnel = require("broccoli-funnel");
 
-const addInRepoTestsToHost = require('../lib/add-in-repo-tests-to-host');
+const addInRepoTestsToHost = require("../lib/add-in-repo-tests-to-host");
 
-describe('add-in-repo-tests-to-host', () => {
-  it('Should always return app unit test trees', async () => {
+describe("add-in-repo-tests-to-host", () => {
+  it("Should always return app unit test trees", async () => {
     const input = await createTempDir();
 
     input.write({
-      'package.json': `foo`,
-      'README.md': 'lol',
-      'ember-cli-build.js': 'bar',
+      "package.json": `foo`,
+      "README.md": "lol",
+      "ember-cli-build.js": "bar",
       tests: {
         unit: {
-          'foo-test.js': `console.log('hello world')`,
+          "foo-test.js": `console.log('hello world')`,
         },
       },
     });
 
     const project = {
-      name: 'foo-app',
+      name: "foo-app",
       addons: [],
       root: input.path(),
     };
@@ -38,33 +38,33 @@ describe('add-in-repo-tests-to-host', () => {
     await output.build();
 
     expect(output.read()).toStrictEqual({
-      unit: { 'foo-test.js': `console.log('hello world')` },
+      unit: { "foo-test.js": `console.log('hello world')` },
     });
 
     input.dispose();
   });
 
-  it('Should merge unit tests of in repo addon', async () => {
+  it("Should merge unit tests of in repo addon", async () => {
     const input = await createTempDir();
 
     input.write({
-      'package.json': `foo`,
-      'README.md': 'lol',
-      'ember-cli-build.js': 'bar',
+      "package.json": `foo`,
+      "README.md": "lol",
+      "ember-cli-build.js": "bar",
       lib: {
         foo: {
-          'index.js': `module.exports = { name: 'foo', includeTestsInHost: true }`,
-          'package.json': `in-repo package.json`,
+          "index.js": `module.exports = { name: 'foo', includeTestsInHost: true }`,
+          "package.json": `in-repo package.json`,
           tests: {
             unit: {
-              'bar-test.js': `console.log('bar-test')`,
+              "bar-test.js": `console.log('bar-test')`,
             },
           },
         },
       },
       tests: {
         unit: {
-          'foo-test.js': `console.log('hello world')`,
+          "foo-test.js": `console.log('hello world')`,
         },
       },
     });
@@ -73,12 +73,12 @@ describe('add-in-repo-tests-to-host', () => {
       root: input.path(),
       addons: [
         {
-          name: 'foo',
+          name: "foo",
           root: `${input.path()}/lib/foo`,
           includeTestsInHost: true,
         },
       ],
-      name: 'foo-app',
+      name: "foo-app",
     };
 
     const node = addInRepoTestsToHost({
@@ -89,38 +89,44 @@ describe('add-in-repo-tests-to-host', () => {
 
     await output.build();
 
-    expect(output.read()).toStrictEqual({
-      'ember-add-in-repo-tests': {
-        foo: {
-          unit: {
-            'bar-test.js': `console.log('bar-test')`,
+    expect(output.read()).toMatchInlineSnapshot(`
+      Object {
+        "ember-add-in-repo-tests": Object {
+          "lib": Object {
+            "foo": Object {
+              "tests": Object {
+                "unit": Object {
+                  "bar-test.js": "console.log('bar-test')",
+                },
+              },
+            },
           },
         },
-      },
-      unit: {
-        'foo-test.js': `console.log('hello world')`,
-      },
-    });
+        "unit": Object {
+          "foo-test.js": "console.log('hello world')",
+        },
+      }
+    `);
 
     input.dispose();
   });
 
-  it('handles addons without test directories', async () => {
+  it("handles addons without test directories", async () => {
     const input = await createTempDir();
 
     input.write({
-      'package.json': `foo`,
-      'README.md': 'lol',
-      'ember-cli-build.js': 'bar',
+      "package.json": `foo`,
+      "README.md": "lol",
+      "ember-cli-build.js": "bar",
       lib: {
         foo: {
-          'index.js': `module.exports = { name: 'foo', includeTestsInHost: true }`,
-          'package.json': `in-repo package.json`,
+          "index.js": `module.exports = { name: 'foo', includeTestsInHost: true }`,
+          "package.json": `in-repo package.json`,
         },
       },
       tests: {
         unit: {
-          'foo-test.js': `console.log('hello world')`,
+          "foo-test.js": `console.log('hello world')`,
         },
       },
     });
@@ -129,12 +135,12 @@ describe('add-in-repo-tests-to-host', () => {
       root: input.path(),
       addons: [
         {
-          name: 'foo',
-          root: input.path('lib/foo'),
+          name: "foo",
+          root: input.path("lib/foo"),
           includeTestsInHost: true,
         },
       ],
-      name: 'foo-app',
+      name: "foo-app",
     };
 
     const node = addInRepoTestsToHost({
@@ -145,23 +151,27 @@ describe('add-in-repo-tests-to-host', () => {
 
     await output.build();
 
-    expect(output.read()).toStrictEqual({
-      unit: { 'foo-test.js': `console.log('hello world')` },
-    });
+    expect(output.read()).toMatchInlineSnapshot(`
+      Object {
+        "unit": Object {
+          "foo-test.js": "console.log('hello world')",
+        },
+      }
+    `);
 
     input.dispose();
   });
 
-  it('filters addons by processing test contents', async () => {
+  it("filters addons by processing test contents", async () => {
     const input = await createTempDir();
 
     input.write({
-      'package.json': `foo`,
-      'README.md': 'lol',
-      'ember-cli-build.js': 'bar',
+      "package.json": `foo`,
+      "README.md": "lol",
+      "ember-cli-build.js": "bar",
       tests: {
         unit: {
-          'foo-test.js': `console.log('hello world')`,
+          "foo-test.js": `console.log('hello world')`,
         },
       },
     });
@@ -169,7 +179,7 @@ describe('add-in-repo-tests-to-host', () => {
     const project = {
       root: input.path(),
       addons: [],
-      name: 'foo-app',
+      name: "foo-app",
     };
 
     const filterRepoAddon = (dir) => {
@@ -177,9 +187,9 @@ describe('add-in-repo-tests-to-host', () => {
         const content = fs
           .readFileSync(file)
           .toString()
-          .replace('console.log', 'console.error');
+          .replace("console.log", "console.error");
 
-        fs.writeFileSync(file, content, 'utf8');
+        fs.writeFileSync(file, content, "utf8");
       });
       return new Funnel(dir);
     };
@@ -193,43 +203,47 @@ describe('add-in-repo-tests-to-host', () => {
 
     await output.build();
 
-    expect(output.read()).toStrictEqual({
-      unit: { 'foo-test.js': `console.error('hello world')` },
-    });
+    expect(output.read()).toMatchInlineSnapshot(`
+      Object {
+        "unit": Object {
+          "foo-test.js": "console.error('hello world')",
+        },
+      }
+    `);
 
     input.dispose();
   });
 
-  it('addon recursively computes test trees based on initial predicate', async () => {
+  it("addon recursively computes test trees based on initial predicate", async () => {
     const input = await createTempDir();
 
     input.write({
-      'package.json': `foo`,
-      'README.md': 'lol',
-      'ember-cli-build.js': 'bar',
+      "package.json": `foo`,
+      "README.md": "lol",
+      "ember-cli-build.js": "bar",
       lib: {
         foo: {
-          'index.js': `module.exports = { name: 'foo', includeTestsInHost: true }`,
-          'package.json': `in-repo package.json`,
+          "index.js": `module.exports = { name: 'foo', includeTestsInHost: true }`,
+          "package.json": `in-repo package.json`,
           tests: {
             unit: {
-              'foo-test.js': `console.log('foo-test')`,
+              "foo-test.js": `console.log('foo-test')`,
             },
           },
         },
-        'bar-foo': {
-          'index.js': `module.exports = { name: 'bar-foo', includeTestsInHost: true }`,
-          'package.json': `in-repo package.json`,
+        "bar-foo": {
+          "index.js": `module.exports = { name: 'bar-foo', includeTestsInHost: true }`,
+          "package.json": `in-repo package.json`,
           tests: {
             unit: {
-              'bar-foo-test.js': `console.log('bar-foo-test')`,
+              "bar-foo-test.js": `console.log('bar-foo-test')`,
             },
           },
         },
       },
       tests: {
         unit: {
-          'foo-test.js': `console.log('hello world')`,
+          "foo-test.js": `console.log('hello world')`,
         },
       },
     });
@@ -238,19 +252,19 @@ describe('add-in-repo-tests-to-host', () => {
       root: input.path(),
       addons: [
         {
-          name: 'foo',
-          root: input.path('lib/foo'),
+          name: "foo",
+          root: input.path("lib/foo"),
           includeTestsInHost: true,
           addons: [
             {
-              name: 'bar-foo',
-              root: input.path('lib/bar-foo'),
+              name: "bar-foo",
+              root: input.path("lib/bar-foo"),
               includeTestsInHost: true,
             },
           ],
         },
       ],
-      name: 'foo-app',
+      name: "foo-app",
     };
 
     const node = addInRepoTestsToHost({
@@ -261,52 +275,60 @@ describe('add-in-repo-tests-to-host', () => {
 
     await output.build();
 
-    expect(output.read()).toStrictEqual({
-      'ember-add-in-repo-tests': {
-        foo: {
-          unit: {
-            'foo-test.js': `console.log('foo-test')`,
+    expect(output.read()).toMatchInlineSnapshot(`
+      Object {
+        "ember-add-in-repo-tests": Object {
+          "lib": Object {
+            "bar-foo": Object {
+              "tests": Object {
+                "unit": Object {
+                  "bar-foo-test.js": "console.log('bar-foo-test')",
+                },
+              },
+            },
+            "foo": Object {
+              "tests": Object {
+                "unit": Object {
+                  "foo-test.js": "console.log('foo-test')",
+                },
+              },
+            },
           },
         },
-        'bar-foo': {
-          unit: {
-            'bar-foo-test.js': `console.log('bar-foo-test')`,
-          },
+        "unit": Object {
+          "foo-test.js": "console.log('hello world')",
         },
-      },
-      unit: {
-        'foo-test.js': `console.log('hello world')`,
-      },
-    });
+      }
+    `);
 
     input.dispose();
   });
 
-  it('detects nested addon even if parent addon does not match predicate', async () => {
+  it("detects nested addon even if parent addon does not match predicate", async () => {
     const input = await createTempDir();
 
     input.write({
-      'package.json': `foo`,
-      'README.md': 'lol',
-      'ember-cli-build.js': 'bar',
+      "package.json": `foo`,
+      "README.md": "lol",
+      "ember-cli-build.js": "bar",
       lib: {
         foo: {
-          'index.js': `module.exports = { name: 'foo' }`,
-          'package.json': `in-repo package.json`,
+          "index.js": `module.exports = { name: 'foo' }`,
+          "package.json": `in-repo package.json`,
         },
-        'bar-foo': {
-          'index.js': `module.exports = { name: 'bar-foo', includeTestsInHost: true }`,
-          'package.json': `in-repo package.json`,
+        "bar-foo": {
+          "index.js": `module.exports = { name: 'bar-foo', includeTestsInHost: true }`,
+          "package.json": `in-repo package.json`,
           tests: {
             unit: {
-              'bar-foo-test.js': `console.log('bar-foo-test')`,
+              "bar-foo-test.js": `console.log('bar-foo-test')`,
             },
           },
         },
       },
       tests: {
         unit: {
-          'foo-test.js': `console.log('hello world')`,
+          "foo-test.js": `console.log('hello world')`,
         },
       },
     });
@@ -315,18 +337,18 @@ describe('add-in-repo-tests-to-host', () => {
       root: input.path(),
       addons: [
         {
-          name: 'foo',
-          root: input.path('lib/foo'),
+          name: "foo",
+          root: input.path("lib/foo"),
           addons: [
             {
-              name: 'bar-foo',
-              root: input.path('lib/bar-foo'),
+              name: "bar-foo",
+              root: input.path("lib/bar-foo"),
               includeTestsInHost: true,
             },
           ],
         },
       ],
-      name: 'foo-app',
+      name: "foo-app",
     };
 
     const node = addInRepoTestsToHost({
@@ -337,52 +359,58 @@ describe('add-in-repo-tests-to-host', () => {
 
     await output.build();
 
-    expect(output.read()).toStrictEqual({
-      'ember-add-in-repo-tests': {
-        'bar-foo': {
-          unit: {
-            'bar-foo-test.js': `console.log('bar-foo-test')`,
+    expect(output.read()).toMatchInlineSnapshot(`
+      Object {
+        "ember-add-in-repo-tests": Object {
+          "lib": Object {
+            "bar-foo": Object {
+              "tests": Object {
+                "unit": Object {
+                  "bar-foo-test.js": "console.log('bar-foo-test')",
+                },
+              },
+            },
           },
         },
-      },
-      unit: {
-        'foo-test.js': `console.log('hello world')`,
-      },
-    });
+        "unit": Object {
+          "foo-test.js": "console.log('hello world')",
+        },
+      }
+    `);
 
     input.dispose();
   });
 
-  it('does not duplicate test files even if addons share a common dependency', async () => {
+  it("does not duplicate test files even if addons share a common dependency", async () => {
     const input = await createTempDir();
 
     input.write({
-      'package.json': `foo-app`,
+      "package.json": `foo-app`,
       lib: {
         foo: {
-          'index.js': `module.exports = { name: 'foo' }`,
-          'package.json': `in-repo package.json`,
+          "index.js": `module.exports = { name: 'foo' }`,
+          "package.json": `in-repo package.json`,
           tests: {
             unit: {
-              'foo-test.js': `console.log('foo-test')`,
+              "foo-test.js": `console.log('foo-test')`,
             },
           },
         },
         bar: {
-          'index.js': `module.exports = { name: 'bar'}`,
-          'package.json': `in-repo package.json`,
+          "index.js": `module.exports = { name: 'bar'}`,
+          "package.json": `in-repo package.json`,
           tests: {
             unit: {
-              'bar-test.js': `console.log('bar-test')`,
+              "bar-test.js": `console.log('bar-test')`,
             },
           },
         },
-        'common-addon': {
-          'index.js': `module.exports = { name: 'common-addon'}`,
-          'package.json': 'in-repo package.json',
+        "common-addon": {
+          "index.js": `module.exports = { name: 'common-addon'}`,
+          "package.json": "in-repo package.json",
           tests: {
             integration: {
-              'common-addon-test.js': `console.log('common-addon-test')`,
+              "common-addon-test.js": `console.log('common-addon-test')`,
             },
           },
         },
@@ -393,31 +421,31 @@ describe('add-in-repo-tests-to-host', () => {
       root: input.path(),
       addons: [
         {
-          name: 'foo',
-          root: input.path('lib/foo'),
+          name: "foo",
+          root: input.path("lib/foo"),
           includeTestsInHost: true,
           addons: [
             {
-              name: 'common-addon',
-              root: input.path('lib/common-addon'),
+              name: "common-addon",
+              root: input.path("lib/common-addon"),
               includeTestsInHost: true,
             },
           ],
         },
         {
-          name: 'bar',
-          root: input.path('lib/bar'),
+          name: "bar",
+          root: input.path("lib/bar"),
           includeTestsInHost: true,
           addons: [
             {
-              name: 'common-addon',
-              root: input.path('lib/common-addon'),
+              name: "common-addon",
+              root: input.path("lib/common-addon"),
               includeTestsInHost: true,
             },
           ],
         },
       ],
-      name: 'foo-app',
+      name: "foo-app",
     };
 
     const node = addInRepoTestsToHost({
@@ -428,25 +456,35 @@ describe('add-in-repo-tests-to-host', () => {
 
     await output.build();
 
-    expect(output.read()).toStrictEqual({
-      'ember-add-in-repo-tests': {
-        foo: {
-          unit: {
-            'foo-test.js': `console.log('foo-test')`,
+    expect(output.read()).toMatchInlineSnapshot(`
+      Object {
+        "ember-add-in-repo-tests": Object {
+          "lib": Object {
+            "bar": Object {
+              "tests": Object {
+                "unit": Object {
+                  "bar-test.js": "console.log('bar-test')",
+                },
+              },
+            },
+            "common-addon": Object {
+              "tests": Object {
+                "integration": Object {
+                  "common-addon-test.js": "console.log('common-addon-test')",
+                },
+              },
+            },
+            "foo": Object {
+              "tests": Object {
+                "unit": Object {
+                  "foo-test.js": "console.log('foo-test')",
+                },
+              },
+            },
           },
         },
-        bar: {
-          unit: {
-            'bar-test.js': `console.log('bar-test')`,
-          },
-        },
-        'common-addon': {
-          integration: {
-            'common-addon-test.js': `console.log('common-addon-test')`,
-          },
-        },
-      },
-    });
+      }
+    `);
 
     input.dispose();
   });

--- a/__tests__/add-tests-to-host-test.js
+++ b/__tests__/add-tests-to-host-test.js
@@ -87,9 +87,11 @@ describe('add-in-repo-tests-to-host', () => {
     await output.build();
 
     expect(output.read()).toStrictEqual({
-      foo: {
-        unit: {
-          'bar-test.js': `console.log('bar-test')`,
+      'ember-add-in-repo-tests': {
+        foo: {
+          unit: {
+            'bar-test.js': `console.log('bar-test')`,
+          },
         },
       },
       unit: {
@@ -257,14 +259,16 @@ describe('add-in-repo-tests-to-host', () => {
     await output.build();
 
     expect(output.read()).toStrictEqual({
-      foo: {
-        unit: {
-          'foo-test.js': `console.log('foo-test')`,
+      'ember-add-in-repo-tests': {
+        foo: {
+          unit: {
+            'foo-test.js': `console.log('foo-test')`,
+          },
         },
-      },
-      'bar-foo': {
-        unit: {
-          'bar-foo-test.js': `console.log('bar-foo-test')`,
+        'bar-foo': {
+          unit: {
+            'bar-foo-test.js': `console.log('bar-foo-test')`,
+          },
         },
       },
       unit: {
@@ -331,9 +335,11 @@ describe('add-in-repo-tests-to-host', () => {
     await output.build();
 
     expect(output.read()).toStrictEqual({
-      'bar-foo': {
-        unit: {
-          'bar-foo-test.js': `console.log('bar-foo-test')`,
+      'ember-add-in-repo-tests': {
+        'bar-foo': {
+          unit: {
+            'bar-foo-test.js': `console.log('bar-foo-test')`,
+          },
         },
       },
       unit: {
@@ -420,19 +426,21 @@ describe('add-in-repo-tests-to-host', () => {
     await output.build();
 
     expect(output.read()).toStrictEqual({
-      foo: {
-        unit: {
-          'foo-test.js': `console.log('foo-test')`,
+      'ember-add-in-repo-tests': {
+        foo: {
+          unit: {
+            'foo-test.js': `console.log('foo-test')`,
+          },
         },
-      },
-      bar: {
-        unit: {
-          'bar-test.js': `console.log('bar-test')`,
+        bar: {
+          unit: {
+            'bar-test.js': `console.log('bar-test')`,
+          },
         },
-      },
-      'common-addon': {
-        integration: {
-          'common-addon-test.js': `console.log('common-addon-test')`,
+        'common-addon': {
+          integration: {
+            'common-addon-test.js': `console.log('common-addon-test')`,
+          },
         },
       },
     });

--- a/__tests__/add-tests-to-host-test.js
+++ b/__tests__/add-tests-to-host-test.js
@@ -1,30 +1,30 @@
-"use strict";
+'use strict';
 
-const { createTempDir, createBuilder } = require("broccoli-test-helper");
-const { glob } = require("glob");
+const { createTempDir, createBuilder } = require('broccoli-test-helper');
+const { glob } = require('glob');
 
-const fs = require("fs");
-const Funnel = require("broccoli-funnel");
+const fs = require('fs');
+const Funnel = require('broccoli-funnel');
 
-const addInRepoTestsToHost = require("../lib/add-in-repo-tests-to-host");
+const addInRepoTestsToHost = require('../lib/add-in-repo-tests-to-host');
 
-describe("add-in-repo-tests-to-host", () => {
-  it("Should always return app unit test trees", async () => {
+describe('add-in-repo-tests-to-host', () => {
+  it('Should always return app unit test trees', async () => {
     const input = await createTempDir();
 
     input.write({
-      "package.json": `foo`,
-      "README.md": "lol",
-      "ember-cli-build.js": "bar",
+      'package.json': `foo`,
+      'README.md': 'lol',
+      'ember-cli-build.js': 'bar',
       tests: {
         unit: {
-          "foo-test.js": `console.log('hello world')`,
+          'foo-test.js': `console.log('hello world')`,
         },
       },
     });
 
     const project = {
-      name: "foo-app",
+      name: 'foo-app',
       addons: [],
       root: input.path(),
     };
@@ -38,33 +38,33 @@ describe("add-in-repo-tests-to-host", () => {
     await output.build();
 
     expect(output.read()).toStrictEqual({
-      unit: { "foo-test.js": `console.log('hello world')` },
+      unit: { 'foo-test.js': `console.log('hello world')` },
     });
 
     input.dispose();
   });
 
-  it("Should merge unit tests of in repo addon", async () => {
+  it('Should merge unit tests of in repo addon', async () => {
     const input = await createTempDir();
 
     input.write({
-      "package.json": `foo`,
-      "README.md": "lol",
-      "ember-cli-build.js": "bar",
+      'package.json': `foo`,
+      'README.md': 'lol',
+      'ember-cli-build.js': 'bar',
       lib: {
         foo: {
-          "index.js": `module.exports = { name: 'foo', includeTestsInHost: true }`,
-          "package.json": `in-repo package.json`,
+          'index.js': `module.exports = { name: 'foo', includeTestsInHost: true }`,
+          'package.json': `in-repo package.json`,
           tests: {
             unit: {
-              "bar-test.js": `console.log('bar-test')`,
+              'bar-test.js': `console.log('bar-test')`,
             },
           },
         },
       },
       tests: {
         unit: {
-          "foo-test.js": `console.log('hello world')`,
+          'foo-test.js': `console.log('hello world')`,
         },
       },
     });
@@ -73,12 +73,12 @@ describe("add-in-repo-tests-to-host", () => {
       root: input.path(),
       addons: [
         {
-          name: "foo",
+          name: 'foo',
           root: `${input.path()}/lib/foo`,
           includeTestsInHost: true,
         },
       ],
-      name: "foo-app",
+      name: 'foo-app',
     };
 
     const node = addInRepoTestsToHost({
@@ -111,22 +111,22 @@ describe("add-in-repo-tests-to-host", () => {
     input.dispose();
   });
 
-  it("handles addons without test directories", async () => {
+  it('handles addons without test directories', async () => {
     const input = await createTempDir();
 
     input.write({
-      "package.json": `foo`,
-      "README.md": "lol",
-      "ember-cli-build.js": "bar",
+      'package.json': `foo`,
+      'README.md': 'lol',
+      'ember-cli-build.js': 'bar',
       lib: {
         foo: {
-          "index.js": `module.exports = { name: 'foo', includeTestsInHost: true }`,
-          "package.json": `in-repo package.json`,
+          'index.js': `module.exports = { name: 'foo', includeTestsInHost: true }`,
+          'package.json': `in-repo package.json`,
         },
       },
       tests: {
         unit: {
-          "foo-test.js": `console.log('hello world')`,
+          'foo-test.js': `console.log('hello world')`,
         },
       },
     });
@@ -135,12 +135,12 @@ describe("add-in-repo-tests-to-host", () => {
       root: input.path(),
       addons: [
         {
-          name: "foo",
-          root: input.path("lib/foo"),
+          name: 'foo',
+          root: input.path('lib/foo'),
           includeTestsInHost: true,
         },
       ],
-      name: "foo-app",
+      name: 'foo-app',
     };
 
     const node = addInRepoTestsToHost({
@@ -162,16 +162,16 @@ describe("add-in-repo-tests-to-host", () => {
     input.dispose();
   });
 
-  it("filters addons by processing test contents", async () => {
+  it('filters addons by processing test contents', async () => {
     const input = await createTempDir();
 
     input.write({
-      "package.json": `foo`,
-      "README.md": "lol",
-      "ember-cli-build.js": "bar",
+      'package.json': `foo`,
+      'README.md': 'lol',
+      'ember-cli-build.js': 'bar',
       tests: {
         unit: {
-          "foo-test.js": `console.log('hello world')`,
+          'foo-test.js': `console.log('hello world')`,
         },
       },
     });
@@ -179,7 +179,7 @@ describe("add-in-repo-tests-to-host", () => {
     const project = {
       root: input.path(),
       addons: [],
-      name: "foo-app",
+      name: 'foo-app',
     };
 
     const filterRepoAddon = (dir) => {
@@ -187,9 +187,9 @@ describe("add-in-repo-tests-to-host", () => {
         const content = fs
           .readFileSync(file)
           .toString()
-          .replace("console.log", "console.error");
+          .replace('console.log', 'console.error');
 
-        fs.writeFileSync(file, content, "utf8");
+        fs.writeFileSync(file, content, 'utf8');
       });
       return new Funnel(dir);
     };
@@ -214,36 +214,36 @@ describe("add-in-repo-tests-to-host", () => {
     input.dispose();
   });
 
-  it("addon recursively computes test trees based on initial predicate", async () => {
+  it('addon recursively computes test trees based on initial predicate', async () => {
     const input = await createTempDir();
 
     input.write({
-      "package.json": `foo`,
-      "README.md": "lol",
-      "ember-cli-build.js": "bar",
+      'package.json': `foo`,
+      'README.md': 'lol',
+      'ember-cli-build.js': 'bar',
       lib: {
         foo: {
-          "index.js": `module.exports = { name: 'foo', includeTestsInHost: true }`,
-          "package.json": `in-repo package.json`,
+          'index.js': `module.exports = { name: 'foo', includeTestsInHost: true }`,
+          'package.json': `in-repo package.json`,
           tests: {
             unit: {
-              "foo-test.js": `console.log('foo-test')`,
+              'foo-test.js': `console.log('foo-test')`,
             },
           },
         },
-        "bar-foo": {
-          "index.js": `module.exports = { name: 'bar-foo', includeTestsInHost: true }`,
-          "package.json": `in-repo package.json`,
+        'bar-foo': {
+          'index.js': `module.exports = { name: 'bar-foo', includeTestsInHost: true }`,
+          'package.json': `in-repo package.json`,
           tests: {
             unit: {
-              "bar-foo-test.js": `console.log('bar-foo-test')`,
+              'bar-foo-test.js': `console.log('bar-foo-test')`,
             },
           },
         },
       },
       tests: {
         unit: {
-          "foo-test.js": `console.log('hello world')`,
+          'foo-test.js': `console.log('hello world')`,
         },
       },
     });
@@ -252,19 +252,19 @@ describe("add-in-repo-tests-to-host", () => {
       root: input.path(),
       addons: [
         {
-          name: "foo",
-          root: input.path("lib/foo"),
+          name: 'foo',
+          root: input.path('lib/foo'),
           includeTestsInHost: true,
           addons: [
             {
-              name: "bar-foo",
-              root: input.path("lib/bar-foo"),
+              name: 'bar-foo',
+              root: input.path('lib/bar-foo'),
               includeTestsInHost: true,
             },
           ],
         },
       ],
-      name: "foo-app",
+      name: 'foo-app',
     };
 
     const node = addInRepoTestsToHost({
@@ -304,31 +304,31 @@ describe("add-in-repo-tests-to-host", () => {
     input.dispose();
   });
 
-  it("detects nested addon even if parent addon does not match predicate", async () => {
+  it('detects nested addon even if parent addon does not match predicate', async () => {
     const input = await createTempDir();
 
     input.write({
-      "package.json": `foo`,
-      "README.md": "lol",
-      "ember-cli-build.js": "bar",
+      'package.json': `foo`,
+      'README.md': 'lol',
+      'ember-cli-build.js': 'bar',
       lib: {
         foo: {
-          "index.js": `module.exports = { name: 'foo' }`,
-          "package.json": `in-repo package.json`,
+          'index.js': `module.exports = { name: 'foo' }`,
+          'package.json': `in-repo package.json`,
         },
-        "bar-foo": {
-          "index.js": `module.exports = { name: 'bar-foo', includeTestsInHost: true }`,
-          "package.json": `in-repo package.json`,
+        'bar-foo': {
+          'index.js': `module.exports = { name: 'bar-foo', includeTestsInHost: true }`,
+          'package.json': `in-repo package.json`,
           tests: {
             unit: {
-              "bar-foo-test.js": `console.log('bar-foo-test')`,
+              'bar-foo-test.js': `console.log('bar-foo-test')`,
             },
           },
         },
       },
       tests: {
         unit: {
-          "foo-test.js": `console.log('hello world')`,
+          'foo-test.js': `console.log('hello world')`,
         },
       },
     });
@@ -337,18 +337,18 @@ describe("add-in-repo-tests-to-host", () => {
       root: input.path(),
       addons: [
         {
-          name: "foo",
-          root: input.path("lib/foo"),
+          name: 'foo',
+          root: input.path('lib/foo'),
           addons: [
             {
-              name: "bar-foo",
-              root: input.path("lib/bar-foo"),
+              name: 'bar-foo',
+              root: input.path('lib/bar-foo'),
               includeTestsInHost: true,
             },
           ],
         },
       ],
-      name: "foo-app",
+      name: 'foo-app',
     };
 
     const node = addInRepoTestsToHost({
@@ -381,36 +381,36 @@ describe("add-in-repo-tests-to-host", () => {
     input.dispose();
   });
 
-  it("does not duplicate test files even if addons share a common dependency", async () => {
+  it('does not duplicate test files even if addons share a common dependency', async () => {
     const input = await createTempDir();
 
     input.write({
-      "package.json": `foo-app`,
+      'package.json': `foo-app`,
       lib: {
         foo: {
-          "index.js": `module.exports = { name: 'foo' }`,
-          "package.json": `in-repo package.json`,
+          'index.js': `module.exports = { name: 'foo' }`,
+          'package.json': `in-repo package.json`,
           tests: {
             unit: {
-              "foo-test.js": `console.log('foo-test')`,
+              'foo-test.js': `console.log('foo-test')`,
             },
           },
         },
         bar: {
-          "index.js": `module.exports = { name: 'bar'}`,
-          "package.json": `in-repo package.json`,
+          'index.js': `module.exports = { name: 'bar'}`,
+          'package.json': `in-repo package.json`,
           tests: {
             unit: {
-              "bar-test.js": `console.log('bar-test')`,
+              'bar-test.js': `console.log('bar-test')`,
             },
           },
         },
-        "common-addon": {
-          "index.js": `module.exports = { name: 'common-addon'}`,
-          "package.json": "in-repo package.json",
+        'common-addon': {
+          'index.js': `module.exports = { name: 'common-addon'}`,
+          'package.json': 'in-repo package.json',
           tests: {
             integration: {
-              "common-addon-test.js": `console.log('common-addon-test')`,
+              'common-addon-test.js': `console.log('common-addon-test')`,
             },
           },
         },
@@ -421,31 +421,31 @@ describe("add-in-repo-tests-to-host", () => {
       root: input.path(),
       addons: [
         {
-          name: "foo",
-          root: input.path("lib/foo"),
+          name: 'foo',
+          root: input.path('lib/foo'),
           includeTestsInHost: true,
           addons: [
             {
-              name: "common-addon",
-              root: input.path("lib/common-addon"),
+              name: 'common-addon',
+              root: input.path('lib/common-addon'),
               includeTestsInHost: true,
             },
           ],
         },
         {
-          name: "bar",
-          root: input.path("lib/bar"),
+          name: 'bar',
+          root: input.path('lib/bar'),
           includeTestsInHost: true,
           addons: [
             {
-              name: "common-addon",
-              root: input.path("lib/common-addon"),
+              name: 'common-addon',
+              root: input.path('lib/common-addon'),
               includeTestsInHost: true,
             },
           ],
         },
       ],
-      name: "foo-app",
+      name: 'foo-app',
     };
 
     const node = addInRepoTestsToHost({

--- a/__tests__/add-tests-to-host-test.js
+++ b/__tests__/add-tests-to-host-test.js
@@ -29,7 +29,10 @@ describe('add-in-repo-tests-to-host', () => {
       root: input.path(),
     };
 
-    const node = addInRepoTestsToHost(project, () => false);
+    const node = addInRepoTestsToHost({
+      project,
+      shouldIncludeTestsInHost: () => false,
+    });
     const output = createBuilder(node);
 
     await output.build();
@@ -78,10 +81,10 @@ describe('add-in-repo-tests-to-host', () => {
       name: 'foo-app',
     };
 
-    const node = addInRepoTestsToHost(
+    const node = addInRepoTestsToHost({
       project,
-      (addon) => addon.includeTestsInHost
-    );
+      shouldIncludeTestsInHost: (addon) => addon.includeTestsInHost,
+    });
     const output = createBuilder(node);
 
     await output.build();
@@ -134,10 +137,10 @@ describe('add-in-repo-tests-to-host', () => {
       name: 'foo-app',
     };
 
-    const node = addInRepoTestsToHost(
+    const node = addInRepoTestsToHost({
       project,
-      (addon) => addon.includeTestsInHost
-    );
+      shouldIncludeTestsInHost: (addon) => addon.includeTestsInHost,
+    });
     const output = createBuilder(node);
 
     await output.build();
@@ -181,11 +184,11 @@ describe('add-in-repo-tests-to-host', () => {
       return new Funnel(dir);
     };
 
-    const node = await addInRepoTestsToHost(
+    const node = addInRepoTestsToHost({
       project,
-      (addon) => addon.includeTestsInHost,
-      filterRepoAddon
-    );
+      shouldIncludeTestsInHost: (addon) => addon.includeTestsInHost,
+      processTests: filterRepoAddon,
+    });
     const output = createBuilder(node);
 
     await output.build();
@@ -250,10 +253,10 @@ describe('add-in-repo-tests-to-host', () => {
       name: 'foo-app',
     };
 
-    const node = addInRepoTestsToHost(
+    const node = addInRepoTestsToHost({
       project,
-      (addon) => addon.includeTestsInHost
-    );
+      shouldIncludeTestsInHost: (addon) => addon.includeTestsInHost,
+    });
     const output = createBuilder(node);
 
     await output.build();
@@ -326,10 +329,10 @@ describe('add-in-repo-tests-to-host', () => {
       name: 'foo-app',
     };
 
-    const node = addInRepoTestsToHost(
+    const node = addInRepoTestsToHost({
       project,
-      (addon) => addon.includeTestsInHost
-    );
+      shouldIncludeTestsInHost: (addon) => addon.includeTestsInHost,
+    });
     const output = createBuilder(node);
 
     await output.build();
@@ -417,10 +420,10 @@ describe('add-in-repo-tests-to-host', () => {
       name: 'foo-app',
     };
 
-    const node = addInRepoTestsToHost(
+    const node = addInRepoTestsToHost({
       project,
-      (addon) => addon.includeTestsInHost
-    );
+      shouldIncludeTestsInHost: (addon) => addon.includeTestsInHost,
+    });
     const output = createBuilder(node);
 
     await output.build();

--- a/lib/add-in-repo-tests-to-host.js
+++ b/lib/add-in-repo-tests-to-host.js
@@ -5,6 +5,8 @@ const { MergeTrees } = require('broccoli-merge-trees');
 const Funnel = require('broccoli-funnel');
 const flattenAddons = require('./flatten-addons');
 
+const DEFAULT_PROCESS_TESTS = (_path) => _path;
+
 const generateTreeFromPath = (path, processTests) =>
   existsSync(path) ? processTests(new WatchedDir(path)) : null;
 
@@ -24,12 +26,15 @@ const getInRepoAddonTestTrees = (inRepoAddons, processTests) => {
   });
 };
 
-module.exports = (emberProject, predicate, processTests = (_) => _) => {
-  if (!emberProject || !emberProject.root) {
+module.exports = (options) => {
+  const { project, shouldIncludeTestsInHost } = options;
+  let processTests = options.processTests || DEFAULT_PROCESS_TESTS;
+
+  if (!project || !project.root) {
     return null;
   }
 
-  const flattenedAddons = flattenAddons(emberProject.addons);
+  const flattenedAddons = flattenAddons(project.addons);
   // we need flattenedAddons to be a unique set, otherwise tests get overriden
   // if two addons have a common dependency
   const uniqueFlattenedAddons = flattenedAddons.filter(
@@ -38,8 +43,8 @@ module.exports = (emberProject, predicate, processTests = (_) => _) => {
       index
   );
 
-  const projectTestsPath = path.join(emberProject.root, 'tests');
-  const inRepoAddons = uniqueFlattenedAddons.filter(predicate);
+  const projectTestsPath = path.join(project.root, 'tests');
+  const inRepoAddons = uniqueFlattenedAddons.filter(shouldIncludeTestsInHost);
   const inRepoAddonsTestTrees = getInRepoAddonTestTrees(
     inRepoAddons,
     processTests

--- a/lib/add-in-repo-tests-to-host.js
+++ b/lib/add-in-repo-tests-to-host.js
@@ -10,29 +10,42 @@ const DEFAULT_PROCESS_TESTS = (_path) => _path;
 const generateTreeFromPath = (path, processTests) =>
   existsSync(path) ? processTests(new WatchedDir(path)) : null;
 
-const getInRepoAddonTestTrees = (inRepoAddons, processTests) => {
+const getInRepoAddonTestTrees = ({
+  inRepoAddons,
+  projectRoot,
+  processTests,
+}) => {
   if (inRepoAddons.length === 0) {
     return [null];
   }
 
   return inRepoAddons.map((inRepoAddon) => {
-    const inRepoAddonTestPath = `${inRepoAddon.root}/tests`;
+    const absoluteInRepoAddonTestsPath = `${inRepoAddon.root}/tests`;
+    const relativeInRepoAddonTestsPath = path.relative(
+      projectRoot,
+      absoluteInRepoAddonTestsPath
+    );
 
-    return existsSync(inRepoAddonTestPath)
-      ? new Funnel(processTests(inRepoAddonTestPath), {
-          destDir: path.join('ember-add-in-repo-tests', inRepoAddon.name),
+    return existsSync(absoluteInRepoAddonTestsPath)
+      ? new Funnel(processTests(absoluteInRepoAddonTestsPath), {
+          destDir: path.join(
+            'ember-add-in-repo-tests',
+            relativeInRepoAddonTestsPath
+          ),
         })
       : null;
   });
 };
 
 module.exports = (options) => {
-  const { project, shouldIncludeTestsInHost } = options;
+  let { project, projectRoot, shouldIncludeTestsInHost } = options;
   let processTests = options.processTests || DEFAULT_PROCESS_TESTS;
 
   if (!project || !project.root) {
     return null;
   }
+
+  projectRoot = projectRoot || project.root;
 
   const flattenedAddons = flattenAddons(project.addons);
   // we need flattenedAddons to be a unique set, otherwise tests get overriden
@@ -45,10 +58,11 @@ module.exports = (options) => {
 
   const projectTestsPath = path.join(project.root, 'tests');
   const inRepoAddons = uniqueFlattenedAddons.filter(shouldIncludeTestsInHost);
-  const inRepoAddonsTestTrees = getInRepoAddonTestTrees(
+  const inRepoAddonsTestTrees = getInRepoAddonTestTrees({
     inRepoAddons,
-    processTests
-  );
+    projectRoot,
+    processTests,
+  });
 
   return new MergeTrees(
     [

--- a/lib/add-in-repo-tests-to-host.js
+++ b/lib/add-in-repo-tests-to-host.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const { existsSync } = require('fs');
 const { WatchedDir } = require('broccoli-source');
-const mergeTrees = require('broccoli-merge-trees');
+const { MergeTrees } = require('broccoli-merge-trees');
 const Funnel = require('broccoli-funnel');
 const flattenAddons = require('./flatten-addons');
 
@@ -18,7 +18,7 @@ const getInRepoAddonTestTrees = (inRepoAddons, processTests) => {
 
     return existsSync(inRepoAddonTestPath)
       ? new Funnel(processTests(inRepoAddonTestPath), {
-          destDir: inRepoAddon.name,
+          destDir: path.join('ember-add-in-repo-tests', inRepoAddon.name),
         })
       : null;
   });
@@ -45,7 +45,7 @@ module.exports = (emberProject, predicate, processTests = (_) => _) => {
     processTests
   );
 
-  return mergeTrees(
+  return new MergeTrees(
     [
       ...inRepoAddonsTestTrees,
       generateTreeFromPath(projectTestsPath, processTests),


### PR DESCRIPTION
In order to more clearly identify the origin of an in-repo addon's test file after it's merged into the app tree's test tree, this PR adds a deterministic prefix (using the addon's name) in addition to using the physical file path after that prefix.

eg. The physical path starts at the <app> directory, or the root of the Ember app project.

Physical path: `lib/<inRepoAddonName>/<testType>/foo-test.js`
Merged path:   `/Users/tester/root/<app>/tests/ember-add-in-repo-tests/lib/<inRepoAddonName>/<testType>/foo-test.js`

This allows us to 'trim off' the segments up to and including the "ember-add-in-repo-tests" prefix, which leaves us with the physical path.