### PR TITLE
Adds .prettierrc.js

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'es5',
+  printWidth: 100,
+};


### PR DESCRIPTION
Fixes issue where jest attempts to generate inline snapshots and incorrectly uses default prettier settings.

I confirmed this works by running `jest -u`.